### PR TITLE
Add R analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,16 @@ Both `Experiment/CDT.py` and `Main Experiment/CDT.py` now provide an optional
 artificial mouse movements and key presses so that CSV data can be produced
 without a human participant. This is useful for quickly testing analysis
 pipelines during piloting.
+
+## Data analysis
+
+An example R script for analysing output CSV files is available in `Scripts/analysis.R`.
+It aggregates participant data, computes accuracy, d-prime and metacognitive measures using
+Fleming's HMeta-d toolbox, and performs the repeated measures ANOVA and mixed-effects
+models described in the main analysis plan.
+
+Run the script from the repository root with:
+
+```bash
+Rscript Scripts/analysis.R
+```


### PR DESCRIPTION
## Summary
- add `Scripts/analysis.R` which reads participant CSVs, computes SDT metrics with HMeta-d and runs the planned statistical tests
- document usage of the new script in the README

## Testing
- `pip install numpy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842a8d72370832bb321524fb2da6f26